### PR TITLE
fix dictionary opposite reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ Now manually inspect the output of the `.lang` file using vim:
 $ vim outputs/geoTwitter20-02-16.zip.lang
 ```
 You should see that the file contains a dictionary of dictionaries.
-The outermost dictionary has languages as the keys, 
-and the innermost dictionary has hashtags as the keys.
+The outermost dictionary has hashtags as the keys,
+and the innermost dictionary has languages as the keys.
 The `visualize.py` file simply provides a nicer visualization of these dictionaries.
 
 **Task 2: Reduce**


### PR DESCRIPTION
It appears that the modified version more accurately describes the structure of the dictionaries. This is what the json looks like:

```json
{
    "#virus": {
        "es": 49,
        "pt": 41,
        "en": 85,
        "th": 1,
        "und": 54,
        "eu": 1,
        "fr": 7,
        "in": 9,
        "tl": 2,
        "hi": 7,
        "de": 5,
        "mr": 2,
        "sr": 1,
        "nl": 2,
        "it": 2,
        "bn": 1,
        "pl": 1,
        "et": 1,
        "tr": 1
    },
    "#sneeze": {
        "en": 2
    },
    "#cough": {
        "en": 2
    }
}
```